### PR TITLE
Allow multiple of the same entity in a world

### DIFF
--- a/lib/draco.rb
+++ b/lib/draco.rb
@@ -373,7 +373,7 @@ module Draco
 
   # Public: The container for current Entities and Systems.
   class World
-    @default_entities = {}
+    @default_entities = []
     @default_systems = []
 
     # Internal: Resets the default components for each class that inherites Entity.
@@ -383,7 +383,7 @@ module Draco
     # Returns nothing.
     def self.inherited(sub)
       super
-      sub.instance_variable_set(:@default_entities, {})
+      sub.instance_variable_set(:@default_entities, [])
       sub.instance_variable_set(:@default_systems, [])
     end
 
@@ -401,7 +401,7 @@ module Draco
     # Returns nothing.
     def self.entity(entity, defaults = {})
       name = defaults[:as]
-      @default_entities[entity] = defaults
+      @default_entities.push([entity, defaults])
 
       attr_reader(name.to_sym) if name
     end
@@ -440,7 +440,8 @@ module Draco
     # entities - The Array of Entities for the World (default: []).
     # systems - The Array of System Classes for the World (default: []).
     def initialize(entities: [], systems: [])
-      default_entities = self.class.default_entities.map do |klass, attributes|
+      default_entities = self.class.default_entities.map do |default|
+        klass, attributes = default
         name = attributes[:as]
         entity = klass.new(attributes)
         instance_variable_set("@#{name}", entity) if name

--- a/spec/draco/world_spec.rb
+++ b/spec/draco/world_spec.rb
@@ -28,6 +28,7 @@ end
 
 class SampleWorld < Draco::World
   entity WorldEntity
+  entity WorldEntity
   entity FilteredEntity, filtered_component: { tested: true }, as: :filtered_entity
   systems WorldSystem
 end
@@ -153,6 +154,7 @@ RSpec.describe Draco::World do
 
     it "has default entities" do
       expect(world.entities).to_not be_empty
+      expect(world.entities.count).to eq(3)
       expect(world.entities[FilteredComponent].first.filtered_component.tested).to be true
     end
 


### PR DESCRIPTION
```ruby
class Overworld < Draco::World
  entity Player, position: { x: 50, y: 50 }, as: :player1
  entity Player, position: { x: 500, y: 500 }, as: :player2
end
```