### PR TITLE
A quick and easy patch to monitor the average time each system runs per tick

### DIFF
--- a/lib/draco_timer.rb
+++ b/lib/draco_timer.rb
@@ -1,0 +1,53 @@
+module Draco
+  class World
+    attr_accessor :system_timer_data
+
+    old_tick = instance_method(:tick)
+
+    def system_timer(system)
+      raise "Enable using #enable_system_timer!" unless @use_system_timer
+
+      a = @system_timer_data[system].last(100)
+      a.inject { |sum, n| sum + n } / a.size.to_f
+    end
+
+    def system_timers
+      raise "Enable using #enable_system_timer!" unless @use_system_timer
+
+      report = {}
+      @system_timer_data.keys.each do |k|
+        report[k] = (system_timer(k) * 1000.0).round(5)
+      end
+      report.sort_by { |k,v| -v }.to_h
+    end
+
+    def enable_system_timer!
+      @system_timer_data ||= {}
+      @use_system_timer = true
+    end
+
+    def disable_system_timer!
+      @system_timer_data = {}
+      @use_system_timer = false
+    end
+
+    define_method(:tick) do |context|
+      if @use_system_timer
+        systems.each do |system|
+          entities = filter(system.filter)
+
+          start_time = Time.now
+          system.new(entities: entities, world: self).tick(context)
+          finish_time = Time.now
+
+          elapsed_time = (finish_time - start_time)
+          name = Draco.underscore(system.name.to_s).to_sym
+          @system_timer_data[name] ||= []
+          @system_timer_data[name] << elapsed_time
+        end
+      else
+        old_tick.bind(self).(context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just a simple way to monitor the performance of your Draco systems and see which one is slowing down your game.

### Usage

1. Copy `lib/draco_timer.rb` into your game and **require** it alongside `draco.rb`
2. After initializing a World, call `$gtk.args.state.world.enable_system_timer!`
3. Call `$gtk.args.state.world.system_timer(:underscored_system_name)` to get the average tick time for a system
4. Call `$gtk.args.state.world.system_timers` to get a the average for all systems (over the last 100 ticks, ordered by slowest first)

### Example

```ruby
-> $gtk.args.state.world.system_timers
=> {:handle_game_start=>0.72592, :render_sprites=>0.09413000000000001, :render_labels=>0.08839, :button_actions=>0.04736, :resize_buttons=>0.03047, :handle_alerts=>0.02963, :render_solids=>0.00684}
```