### PR TITLE
Fixes audio in samples to work with dagonruby v241

### DIFF
--- a/samples/teeny-tiny/app/systems/handle_destroyed.rb
+++ b/samples/teeny-tiny/app/systems/handle_destroyed.rb
@@ -6,7 +6,7 @@ class HandleDestroyed < Draco::System
       explosion = Explosion.new(position: {x: entity.position.x, y: entity.position.y })
       world.entities.delete(entity)
       world.entities.add(explosion)
-      args.gtk.queue_sound("sounds/explosion.ogg")
+      args.outputs.sounds << "sounds/explosion.ogg"
     end
   end
 end

--- a/samples/teeny-tiny/app/systems/spawn_lasers.rb
+++ b/samples/teeny-tiny/app/systems/spawn_lasers.rb
@@ -5,10 +5,10 @@ class SpawnLasers < Draco::System
     entities.reject { |entity| entity.attacking.laser_spawned }.each do |entity|
       if entity.components[:player_controlled]
         world.entities << PlayerLaser.new(position: { x: entity.position.x + 30, y: entity.position.y + 60})
-        args.gtk.queue_sound("sounds/player_laser.ogg")
+        args.outputs.sounds << "sounds/player_laser.ogg"
       else
         world.entities << EnemyLaser.new(position: { x: entity.position.x - 30, y: entity.position.y - 60})
-        args.gtk.queue_sound("sounds/enemy_laser.ogg")
+        args.outputs.sounds << "sounds/enemy_laser.ogg"
       end
 
       entity.attacking.laser_spawned = true


### PR DESCRIPTION
Hi,

Running the sample in the current dragonruby version 241, it crashes with the message the used `queue_sound` method on the GTK runtime is missing a parameter. Sometime in the last year, the `queue_sound` method changed expecting a gain (float 0-1) parameter. See https://github.com/DragonRuby/dragonruby-game-toolkit-contrib/blob/main/dragon/runtime.rb#L886

This did not impact the public interface using `arg.outputs.sounds << "path"` notation, which used in all documentation and examples. I therefore switched the code to this notation and now the example is working fine again. :)

bye,
Dahie